### PR TITLE
Custom split function

### DIFF
--- a/src/merge-logs/main.go
+++ b/src/merge-logs/main.go
@@ -1,18 +1,18 @@
 package main
 
 import (
-	"flag"
-	"merge-logs/mergedlog"
-	"container/list"
-	"regexp"
-	"log"
-	"strings"
-	"os"
 	"bufio"
-	"time"
-	"github.com/mgutz/ansi"
+	"container/list"
+	"flag"
 	"fmt"
+	"github.com/mgutz/ansi"
+	"log"
+	"merge-logs/mergedlog"
+	"os"
+	"regexp"
 	"strconv"
+	"strings"
+	"time"
 )
 
 var MAX_INT = int64(^uint64(0) >> 1)
@@ -62,7 +62,7 @@ func main() {
 	maxLogNameLength := 0
 	var logName, alias string
 	// Gather our files and set up a Scanner for each of them
-	for _, logTagName := range (flag.Args()) {
+	for _, logTagName := range flag.Args() {
 		parts := strings.Split(logTagName, ":")
 		alias = parts[0]
 
@@ -139,9 +139,9 @@ func flushLogs(highestStamp int64, aggLog *list.List, maxLogNameLength int) {
 	for e := aggLog.Front(); e != nil; e = aggLog.Front() {
 		line, _ := e.Value.(*mergedlog.LogLine)
 		if line.UTime < highestStamp {
-			format := "%s%" + strconv.Itoa(len(line.Alias) - maxLogNameLength) + "s[%s] %s%s\n"
+			format := "%s%" + strconv.Itoa(len(line.Alias)-maxLogNameLength) + "s[%s] %s%s\n"
 			if userColor != "off" {
-				fmt.Printf(format, line.Color,  "", line.Alias, line.Text, resetColor)
+				fmt.Printf(format, line.Color, "", line.Alias, line.Text, resetColor)
 			} else {
 				fmt.Printf(format, "", "", line.Alias, line.Text, "")
 			}

--- a/src/merge-logs/main.go
+++ b/src/merge-logs/main.go
@@ -5,7 +5,6 @@ import (
 	"container/list"
 	"flag"
 	"fmt"
-	"github.com/mgutz/ansi"
 	"log"
 	"merge-logs/mergedlog"
 	"os"
@@ -13,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/mgutz/ansi"
 )
 
 var MAX_INT = int64(^uint64(0) >> 1)
@@ -81,7 +82,10 @@ func main() {
 		}
 		defer f.Close()
 
-		logs = append(logs, mergedlog.LogFile{Alias: alias, Scanner: bufio.NewScanner(f), AggLog: aggLog, Color: palette[colorIndex]})
+		scanner := bufio.NewScanner(f)
+		scanner.Split(mergedlog.ScanLogEntries)
+
+		logs = append(logs, mergedlog.LogFile{Alias: alias, Scanner: scanner, AggLog: aggLog, Color: palette[colorIndex]})
 		colorIndex = (colorIndex + 1) % 8
 
 		if len(alias) > maxLogNameLength {
@@ -137,13 +141,15 @@ func main() {
 
 func flushLogs(highestStamp int64, aggLog *list.List, maxLogNameLength int) {
 	for e := aggLog.Front(); e != nil; e = aggLog.Front() {
-		line, _ := e.Value.(*mergedlog.LogLine)
-		if line.UTime < highestStamp {
-			format := "%s%" + strconv.Itoa(len(line.Alias)-maxLogNameLength) + "s[%s] %s%s\n"
-			if userColor != "off" {
-				fmt.Printf(format, line.Color, "", line.Alias, line.Text, resetColor)
-			} else {
-				fmt.Printf(format, "", "", line.Alias, line.Text, "")
+		entry, _ := e.Value.(*mergedlog.LogLine)
+		if entry.UTime < highestStamp {
+			format := "%s%" + strconv.Itoa(len(entry.Alias)-maxLogNameLength) + "s[%s] %s%s\n"
+			for _, line := range strings.Split(entry.Text, "\n") {
+				if userColor != "off" {
+					fmt.Printf(format, entry.Color, "", entry.Alias, line, resetColor)
+				} else {
+					fmt.Printf(format, "", "", entry.Alias, line, "")
+				}
 			}
 			aggLog.Remove(e)
 		} else {

--- a/src/merge-logs/mergedlog/mergedlog_test.go
+++ b/src/merge-logs/mergedlog/mergedlog_test.go
@@ -149,4 +149,34 @@ var _ = Describe("adding lines", func() {
 			Expect(line.Value).To(Equal(line4))
 		})
 	})
+
+	Context("Custom scan function", func() {
+		It("works at the end of a reader with no data", func() {
+			advance, token, err := mergedlog.ScanLogEntries([]byte{}, true)
+			Expect(advance).Should(Equal(0))
+			Expect(token).Should(Equal([]byte{}))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("works at the end of a reader with data", func() {
+			advance, token, err := mergedlog.ScanLogEntries([]byte("line\n"), true)
+			Expect(advance).Should(Equal(5))
+			Expect(token).Should(Equal([]byte("line")))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("requests more data when sep is no present", func() {
+			advance, token, err := mergedlog.ScanLogEntries([]byte("line"), false)
+			Expect(advance).Should(Equal(0))
+			Expect(token).Should(BeNil())
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("requests more data when sep is no present", func() {
+			advance, token, err := mergedlog.ScanLogEntries([]byte("line\n["), false)
+			Expect(advance).Should(Equal(5))
+			Expect(token).Should(Equal([]byte("line")))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
 })


### PR DESCRIPTION
This PR adds a custom scan function for iterating over the log messages contained in a file. Previously, this was done by iterating over the lines in a file and associating lines not containing a timestamp with the last known timestamp. The custom scan function looks for the occurences of a newline followed by `[` to separate groups of lines into single log messages.

A follow-up PR is in the works for adding the ability to filter the log lines based on time to limit the merged logs around a time window of interest. With the line based scanner, it was proving a little hacky to filter the timeless log lines. Adding this custom scanner makes it a little bit easier to filter log entries. Since this results in fewer strings to check the regex against, it is _slightly_ faster.