### PR TITLE
Make the buffer used by Scanner user configurable

### DIFF
--- a/src/merge-logs/main.go
+++ b/src/merge-logs/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"log"
 	"merge-logs/mergedlog"
 	"os"
 	"strings"
 	"time"
+
 	"github.com/mgutz/ansi"
 )
 
@@ -29,6 +31,7 @@ func init() {
 func main() {
 	flag.StringVar(&userColor, "color", "dark", "Color scheme to use: light, dark or off")
 	duration := flag.Int64("duration", mergedlog.MAX_INT, "start of range of logs")
+	maxBuffer := flag.Int("max-buffer", bufio.MaxScanTokenSize, "maximum size of buffer to use when scanning")
 	rangeStopStr := flag.String("stop", "", "start of range of logs")
 	flag.Parse()
 
@@ -77,7 +80,7 @@ func main() {
 		}
 		defer f.Close()
 
-		processor.AddLog(alias, f)
+		processor.AddLog(alias, f, *maxBuffer)
 	}
 
 	processor.Crank()

--- a/src/merge-logs/mergedlog/mergedlog.go
+++ b/src/merge-logs/mergedlog/mergedlog.go
@@ -97,7 +97,7 @@ func ScanLogEntries(data []byte, atEOF bool) (advance int, token []byte, err err
 	// If we're at EOF, we have a final, non-terminated line. Return it,
 	// dropping the trailing newline.
 	if atEOF {
-		return len(data), bytes.TrimRight(data[0:len(data)-1], "\r\n"), nil
+		return len(data), bytes.TrimRight(data[0:len(data)], "\r\n"), nil
 	}
 
 	// Request more data.

--- a/src/merge-logs/mergedlog/mergedlog_test.go
+++ b/src/merge-logs/mergedlog/mergedlog_test.go
@@ -246,9 +246,16 @@ var _ = Describe("adding lines", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 		})
 
-		It("works at the end of a reader with data", func() {
+		It("works at the end of a reader with data with trailing newline", func() {
 			advance, token, err := mergedlog.ScanLogEntries([]byte("line\n"), true)
 			Expect(advance).Should(Equal(5))
+			Expect(token).Should(Equal([]byte("line")))
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("works at the end of a reader with data without trailing newline", func() {
+			advance, token, err := mergedlog.ScanLogEntries([]byte("line"), true)
+			Expect(advance).Should(Equal(4))
 			Expect(token).Should(Equal([]byte("line")))
 			Expect(err).ShouldNot(HaveOccurred())
 		})

--- a/src/merge-logs/mergedlog/processor_test.go
+++ b/src/merge-logs/mergedlog/processor_test.go
@@ -1,10 +1,12 @@
 package mergedlog_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"bufio"
 	"merge-logs/mergedlog"
 	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("processor integration test", func() {
@@ -16,7 +18,7 @@ var _ = Describe("processor integration test", func() {
 
 			file1 := "foo\nbar\nbaz"
 
-			processor.AddLog("", strings.NewReader(file1))
+			processor.AddLog("", strings.NewReader(file1), bufio.MaxScanTokenSize)
 			processor.Crank()
 
 			Expect(result.String()).To(Equal("[] " + strings.Join(strings.Split(file1, "\n"), "\n[] ") + "\n"))
@@ -35,7 +37,7 @@ var _ = Describe("processor integration test", func() {
 
 [fine 2015/11/19 08:52:39.506 PST  line3`
 
-			processor.AddLog("", strings.NewReader(file1))
+			processor.AddLog("", strings.NewReader(file1), bufio.MaxScanTokenSize)
 			processor.Crank()
 
 			Expect(strings.Split(strings.TrimSpace(result.String()), "\n")).To(Equal([]string{
@@ -59,8 +61,8 @@ var _ = Describe("processor integration test", func() {
 [fine 2015/11/19 08:52:39.506 PST  line2`
 			file2 := `[fine 2015/11/19 08:52:39.505 PST  line3`
 
-			processor.AddLog("", strings.NewReader(file1))
-			processor.AddLog("", strings.NewReader(file2))
+			processor.AddLog("", strings.NewReader(file1), bufio.MaxScanTokenSize)
+			processor.AddLog("", strings.NewReader(file2), bufio.MaxScanTokenSize)
 			processor.Crank()
 
 			Expect(strings.Split(strings.TrimSpace(result.String()), "\n")).To(Equal([]string{
@@ -88,8 +90,8 @@ Caused by: AnotherException
 AnotherException
   at acme.com`
 
-			processor.AddLog("", strings.NewReader(file1))
-			processor.AddLog("", strings.NewReader(file2))
+			processor.AddLog("", strings.NewReader(file1), bufio.MaxScanTokenSize)
+			processor.AddLog("", strings.NewReader(file2), bufio.MaxScanTokenSize)
 			processor.Crank()
 
 			Expect(strings.Split(strings.TrimSpace(result.String()), "\n")).To(Equal([]string{


### PR DESCRIPTION
From [0]:

> By default, Scan uses an internal buffer and sets the maximum token
> size to MaxScanTokenSize.

The default value of `MaxScanTokenSize` is only 64k. This means that
lines larger than this value are not emitted by the scanner. This commit
makes the maximum buffer size user configurable; if not configured, the
default of 64k is used.

[0]: https://golang.org/pkg/bufio/#Scanner.Buffer